### PR TITLE
`Coder1248` fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,19 +75,19 @@ for delta coded streams and includes the sum of all values skipped.
 
 | Benchmark         | Throughput    |
 | ----------------- | ------------: |
-| `encode/1       ` | ` 2.5Gelem/s` |
-| `encode_deltas/1` | ` 2.1Gelem/s` |
+| `encode/1       ` | ` 3.1Gelem/s` |
+| `encode_deltas/1` | ` 2.5Gelem/s` |
 | `decode/1       ` | ` 4.6Gelem/s` |
 | `decode_deltas/1` | ` 3.6Gelem/s` |
 | `skip_deltas/1  ` | ` 6.0Gelem/s` |
 | `data_len/1     ` | `53.8Gelem/s` |
-| `encode/4       ` | ` 2.5Gelem/s` |
-| `encode_deltas/4` | ` 2.2Gelem/s` |
+| `encode/4       ` | ` 3.1Gelem/s` |
+| `encode_deltas/4` | ` 2.5Gelem/s` |
 | `decode/4       ` | ` 4.8Gelem/s` |
 | `decode_deltas/4` | ` 3.6Gelem/s` |
 | `skip_deltas/4  ` | ` 5.7Gelem/s` |
-| `encode/8       ` | ` 2.5Gelem/s` |
-| `encode_deltas/8` | ` 2.2Gelem/s` |
+| `encode/8       ` | ` 3.0Gelem/s` |
+| `encode_deltas/8` | ` 2.5Gelem/s` |
 | `decode/8       ` | ` 4.8Gelem/s` |
 | `decode_deltas/8` | ` 3.0Gelem/s` |
 | `skip_deltas/8  ` | ` 5.4Gelem/s` |


### PR DESCRIPTION
Fix a delta coding bug in neon where base was being computed incorrectly.

Improve encoding performance by avoiding a shuffle and store if the group fits in 16 bytes.