### PR TITLE
Bump to version 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streamvbyte64"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 authors = ["Trevor McCulloch <mccullocht@gmail.com>"]
 description = "Implementation of stream-vbyte codec supporting 64-bit wide values"
@@ -13,7 +13,7 @@ crunchy = "0.2.2"
 num-traits = "0.2.15"
 
 [dev-dependencies]
-criterion = "0.3.6"
+criterion = "0.5.1"
 rand = "0.8.5"
 
 [[bench]]

--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ the implementation will automatically use an accelerated implementation for the 
 
 A scalar implementation is available for all `Coder`s but this is typically pretty slow. All
 implementations also include acceleration when building for little-endian `aarch64` with `NEON`
-instruction support, although it should be easy to extend to `x86_64` in the future (contributions
-are welcome).)
+instruction support and `x86_64` using the `SSSE3` or `SSE4.1` instruction sets.
 
 `Coder1234` will typically be fastest, but other tag length distributions (including `Coder1248` for
 64-bit values) are available.)


### PR DESCRIPTION
README touchups since there are now `x86_64` implementations.

Upgrade criterion.